### PR TITLE
BAU: default config values

### DIFF
--- a/.flaskenv
+++ b/.flaskenv
@@ -1,12 +1,4 @@
-CONTACT_EMAIL=test@test.com
-CONTACT_PHONE=
-DEPARTMENT_NAME=DHLUC
-DEPARTMENT_URL=https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities
 FLASK_APP=app.py
 FLASK_DEBUG=True
 FLASK_RUN_PORT=5000
 FLASK_ENV=development
-SERVICE_NAME=BETA
-SERVICE_PHASE=BETA
-SERVICE_URL=
-DATA_STORE_API_HOST='http://localhost:8080/'

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -9,12 +9,19 @@ from fsd_utils import configclass
 class DefaultConfig(object):
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
 
-    CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "dev@dev.com")
+    CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "FSD.Support@levellingup.gov.uk")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "12345678910")
-    DEPARTMENT_NAME = os.environ.get("DEPARTMENT_NAME", "dev-dept-name")
-    DEPARTMENT_URL = os.environ.get("DEPARTMENT_URL", "dev-dept-url")
-    SERVICE_NAME = os.environ.get("SERVICE_NAME", "post-award-frontend")
-    SERVICE_PHASE = os.environ.get("SERVICE_PHASE", "dev-service-phase")
+    DEPARTMENT_NAME = os.environ.get(
+        "DEPARTMENT_NAME", "Department for Levelling Up, Housing and Communities"
+    )
+    DEPARTMENT_URL = os.environ.get(
+        "DEPARTMENT_URL",
+        "https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities",
+    )
+    SERVICE_NAME = os.environ.get(
+        "SERVICE_NAME", "Download monitoring and evaluation data"
+    )
+    SERVICE_PHASE = os.environ.get("SERVICE_PHASE", "BETA")
     SERVICE_URL = os.environ.get("SERVICE_URL", "dev-service-url")
     SESSION_COOKIE_SECURE = True
     DATA_STORE_API_HOST = os.environ.get("DATA_STORE_API_HOST")


### PR DESCRIPTION
### Change description
Previously placeholder values were being overwritten in `.flaskenv`, this created a difference in the deployed environment which doesn't read from this file 
e.g. 
![Screenshot 2023-06-01 at 17 59 44](https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/1764158/23c8f877-4604-4128-9513-f6d9d1845081)

### How to test
placeholder values should no longer appear on deployed environment


### Screenshots of UI changes (if applicable)
![Screenshot 2023-06-01 at 18 00 41](https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/1764158/00424cb1-a4b2-4289-8a28-257d26cac5ee)

