### PR TITLE
Feature/ 433 sign out

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,7 +25,7 @@
     'serviceUrl': url_for('main.download'),
     'navigation': [
     {
-      'href': '#',
+      'href': config['AUTHENTICATOR_HOST'] + "/sso/logout",
       'text': 'Log out',
     },
   ]

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -27,7 +27,6 @@
     {
       'href': '#',
       'text': 'Log out',
-      'active': 'true'
     },
   ]
   }) }}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,7 +25,7 @@
     'serviceUrl': url_for('main.download'),
     'navigation': [
     {
-      'href': config['AUTHENTICATOR_HOST'] + "/sso/logout",
+      'href': config['AUTHENTICATOR_HOST'] + "sessions/sign-out?return_app=post-award-frontend",
       'text': 'Log out',
     },
   ]

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 {%- from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary-%}
 {%- from 'govuk_frontend_jinja/components/notification-banner/macro.html' import govukNotificationBanner -%}
 {%- from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner -%}
+{%- from 'govuk_frontend_jinja/components/header/macro.html' import govukHeader -%}
 
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
 
@@ -20,8 +21,15 @@
 {% block header %}
   {{ govukHeader({
     'homepageUrl': url_for('main.download'),
-    'serviceName': config['SERVICE_NAME'],
-    'serviceUrl': url_for('main.download')
+    'serviceName': 'Find monitoring data',
+    'serviceUrl': url_for('main.download'),
+    'navigation': [
+    {
+      'href': '#',
+      'text': 'Log out',
+      'active': 'true'
+    },
+  ]
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
https://trello.com/c/wEHWANE1/433-front-end-add-sign-out-get-help-links


### Change description
Adds a sign-out link inside the header, as according to the updated prototype


<img width="602" alt="Screenshot 2023-06-02 155210" src="https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/39564632/4dd5e035-00a9-44b6-9fe4-681ea0927210">

