### PR TITLE
change footer component to raw html for customisation

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,8 +13,7 @@
   <meta name="description" content="{{config['SERVICE_NAME']}}">
   <meta name="keywords" content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
   <meta name="author" content="{{config['DEPARTMENT_NAME']}}">
-  <!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-4.6.0.min.css') }}" /><!--<![endif]-->
-  <!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-ie8-4.6.0.min.css') }}" /><![endif]-->
+  <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-4.6.0.min.css') }}" />
   {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
 {% endblock %}
 
@@ -56,25 +55,46 @@
 {% endblock %}
 
 {% block footer %}
-  {{ govukFooter({
-    'meta': {
-      'items': [
-        {
-          'href': url_for('main.accessibility'),
-          'text': 'Accessibility'
-        },
-        {
-          'href': '#',
-          'text': 'Cookies'
-        },
-        {
-            'href': url_for('main.privacy'),
-            'text': 'Privacy'
-          }
-      ],
-      'html': 'Built by <a href="' + config['DEPARTMENT_URL'] +'" class="govuk-footer__link">' + config['DEPARTMENT_NAME'] + '</a>'
-    }
-  }) }}
+  <footer class="govuk-footer " role="contentinfo">
+    <div class="govuk-width-container ">
+      <div class="govuk-footer__meta">
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <div class="govuk-!-margin-bottom-6">
+            <div class="govuk-heading-l">Get Help</div>
+            <p class="govuk-body">If you are experiencing difficulties with this service or have any questions, you can email us.</p>
+            <h3 class="govuk-heading-m">Email</h3>
+            <p class="govuk-body">
+              <a class="govuk-link" href="mailto:FSD.Support@levellingup.gov.uk">fsd.support@levellingup.gov.uk</a>
+            </p>
+            <p class="govuk-body">Monday to Friday: 9am to 5pm (except public holidays).</p>
+            <h2 class="govuk-visually-hidden">Support links</h2>
+            <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41">
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+            </svg>
+            <span class="govuk-footer__licence-description">
+              All content is available under the
+              <a
+                class="govuk-footer__link"
+                href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+            </span>
+            </div>
+            <div class="govuk-footer__meta-item">
+              <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+            </div>
+          </div>
+      </div>
+    </div>
+  </footer>
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
This adds the HTML needed for our custom footer component, as elements such as the title and heading were not part of the govUkFooter nunjucks component.