### PR TITLE
BAU: remove inaccurate info from 500 page

### DIFF
--- a/app/templates/main/500.html
+++ b/app/templates/main/500.html
@@ -9,7 +9,6 @@
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
         <p class="govuk-body">Try again later.</p>
-        <p class="govuk-body">We saved your answers. They will be available for 30 days.</p>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Change description
Spotted in the course of another story.

500 page contained inaccurate information
![Screenshot 2023-06-12 at 12 14 34](https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/1764158/0cafb0d2-d5a6-47e6-9d63-76d1503bccbe)




### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
