### PR TITLE
PAB-306: Add sentry integration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask, request
 from flask_assets import Bundle, Environment
 from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFProtect
+from fsd_utils import init_sentry
 from fsd_utils.authentication.config import SupportedApp
 from fsd_utils.authentication.decorators import login_required
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
@@ -17,6 +18,7 @@ csrf = CSRFProtect()
 
 
 def create_app(config_class=Config):
+    init_sentry()
     app = Flask(__name__, static_url_path="/static")
     csrf.init_app(app)
     app.config.from_object(config_class)

--- a/copilot/data-frontend/manifest.yml
+++ b/copilot/data-frontend/manifest.yml
@@ -39,6 +39,8 @@ variables:                    # Pass environment variables as key value pairs.
  LOG_LEVEL: info
  DATA_STORE_API_HOST: 'http://data-store:8080'
  COOKIE_DOMAIN: '.${COPILOT_ENVIRONMENT_NAME}.gids.dev'
+ # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
+ SENTRY_DSN: https://e63d6f45b69f46b9a381f1f042db363e@o1432034.ingest.sentry.io/4505358184415232
 
 secrets:
     AUTHENTICATOR_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AUTHENTICATOR_HOST # The key is the name of the environment variable, the value is the name of the SSM parameter.


### PR DESCRIPTION
### Change description
Add Sentry integration to alert on exceptions, using existing functionality in utils library.


### How to test
Have tested manually locally. Will not cause any changes locally unless you have `SENTRY_DSN` env var set.
