### PR TITLE
PAB-304: inject git sha env var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,10 @@ jobs:
         run: |
           curl -Lo aws-copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux && chmod +x aws-copilot && sudo mv aws-copilot /usr/local/bin/copilot
 
+      - name: Inject Git SHA into manifest
+        run: |
+          yq -i '.variables.GITHUB_SHA = "${{ github.sha }}"' copilot/data-frontend/manifest.yml
+
       - name: Copilot deploy
         run: |
           copilot deploy --env ${{ inputs.environment || 'test' }}


### PR DESCRIPTION
### Change description
Same change as https://github.com/communitiesuk/funding-service-design-post-award-data-store/pull/141 just for frontend

inject git sha env var

This is used by the app e.g. in the healthcheck and sentry reports to help us better track what version we are running on different environments


### How to test
Have deployed on test, and sha currently viewable at: https://find-monitoring-data.test.gids.dev/healthcheck


### Screenshots of UI changes (if applicable)
![Screenshot 2023-06-22 at 17 06 18](https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/1764158/44a62e73-62db-480f-9d45-eacc85fdbff2)
