### PR TITLE
BAU: Add flask env variable

### DIFF
--- a/copilot/data-frontend/manifest.yml
+++ b/copilot/data-frontend/manifest.yml
@@ -41,6 +41,7 @@ variables:                    # Pass environment variables as key value pairs.
  COOKIE_DOMAIN: '.${COPILOT_ENVIRONMENT_NAME}.gids.dev'
  # Sentry DSN is OK to be public see: https://docs.sentry.io/product/sentry-basics/dsn-explainer/#dsn-utilization
  SENTRY_DSN: https://e63d6f45b69f46b9a381f1f042db363e@o1432034.ingest.sentry.io/4505358184415232
+ FLASK_ENV: ${COPILOT_ENVIRONMENT_NAME}
 
 secrets:
     AUTHENTICATOR_HOST: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AUTHENTICATOR_HOST # The key is the name of the environment variable, the value is the name of the SSM parameter.


### PR DESCRIPTION
### Change description
Previously `dev` was erroneously being used on all environments.

This is [as per data-store](https://github.com/communitiesuk/funding-service-design-post-award-data-store/blob/177eb4201b0281dccec87f14922a8fb41a80911d/copilot/data-store/manifest.yml#L38) and allows us to distinguish the environment e.g. for Sentry and other services.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Will be tested post-deployment


### Screenshots of UI changes (if applicable)
