### PR TITLE
[#PAB-509]: remove bottom border

### DIFF
--- a/app/templates/main/download.html
+++ b/app/templates/main/download.html
@@ -83,6 +83,9 @@
           })
         }}
 
+
+  </section>
+
           {{ form.file_format}}
           {{ form.download }}
 
@@ -91,9 +94,6 @@
     <p class="govuk-body">
       <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for('main.data_glossary') }}">Access the funding glossary</a>
     </p>
-
-
-  </section>
 
 </main>
 


### PR DESCRIPTION
The bottom border on the download page has been moved to below the final accordion in order to match design specifications in ticket https://trello.com/c/BhA3jVBT/509-changing-placement-of-bottom-border-of-final-filter


![Screenshot from 2023-07-27 14-18-44](https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/35725316/5cd45e3b-99e6-4ea5-98ab-24042d6b9933)
