### PR TITLE
[BAU] use isort black profile to prevent pre-commit conflict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+        args: [ "--profile", "black" ]
 #-   repo: https://github.com/Riverside-Healthcare/djLint
 #    rev: v1.24.0
 #    hooks:


### PR DESCRIPTION
### Change description
Configures isort to use a configuration that doesn't conflict with black

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
