### PR TITLE
PAB-397: add basic auth sidecar on test environment

### DIFF
--- a/copilot/data-frontend/manifest.yml
+++ b/copilot/data-frontend/manifest.yml
@@ -55,3 +55,19 @@ environments:
      COOKIE_DOMAIN: '.access-funding.levellingup.gov.uk'
    http:
      alias: find-monitoring-data.access-funding.levellingup.gov.uk
+ test:
+  sidecars:
+    nginx:
+      port: 8087
+      image:
+        location: xscys/nginx-sidecar-basic-auth
+      variables:
+        FORWARD_PORT: 8080
+      secrets:
+        BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+        BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+  http:
+    target_container: 'nginx'
+    healthcheck:
+      path: /healthcheck
+      port: 8080


### PR DESCRIPTION
### Change description
Adds basic auth to the frontend on test using a sidecar

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have deployed on test environment, credentials will be provided to the team separately.


### Screenshots of UI changes (if applicable)
