### PR TITLE
add current timestamp to file download

### DIFF
--- a/app/main/download_data.py
+++ b/app/main/download_data.py
@@ -143,7 +143,7 @@ def generate_financial_years(start_date, end_date):
     return financial_years
 
 
-# TODO decide wether to implement this or leave all quarter options available
+# TODO decide whether to implement this or leave all quarter options available
 def generate_quarters(start_date, end_date):
     """Calculates which quarter the given min and max month resides in
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,5 +1,6 @@
 # isort: off
 import io
+from datetime import datetime
 
 from flask import (
     flash,
@@ -56,7 +57,6 @@ def download():
 
     if request.method == "POST":
         file_format = form.file_format.data
-
         if file_format not in ["json", "xlsx"]:
             current_app.logger.error(
                 f"Unexpected file format requested from /download: {file_format}"
@@ -71,6 +71,8 @@ def download():
         from_year = request.form.get("from-year")
         to_quarter = request.form.get("to-quarter")
         to_year = request.form.get("to-year")
+
+        current_datetime = datetime.now().strftime("%Y-%m-%d-%H%M%S")
 
         reporting_period_start = (
             quarter_to_date(quarter=from_quarter, year=from_year)
@@ -103,6 +105,7 @@ def download():
         )
 
         content_type = response.headers["content-type"]
+
         match content_type:
             case MIMETYPE.JSON:
                 file_content = io.BytesIO(json.dumps(response.json()).encode("UTF-8"))
@@ -116,7 +119,7 @@ def download():
 
         return send_file(
             file_content,
-            download_name=f"data.{file_format}",
+            download_name=f"download-{current_datetime}.{file_format}",
             as_attachment=True,
             mimetype=content_type,
         )


### PR DESCRIPTION
https://trello.com/c/dq3Y7Cgn/575-add-timestamp-to-data-extract-filename


### Change description
These changes were originally made in the back-end repo, however there was some confusion as to where the filename is set. The content-disposition header is actually being set in both repos, however the file recieved by the user is overwritten by the headers in the front-end, which is why I chose to move this logic here. The plan is to revert the changes set in the data store repo to avoid repeated code, so downloading a file via the Swagger UI will revert to the previous data.extension pattern.


### How to test
The file downloaded via the front-end UI should now read yyyy-mm-dd-hhmmss.format

