### PR TITLE
[BAU_FIX] increase gunicorn worker timeout from 60 to 120

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ COPY . .
 EXPOSE 8080
 
 ENV FLASK_ENV=dev
-ENV GUNICORN_CMD_ARGS="--timeout 60 --workers 3"
+ENV GUNICORN_CMD_ARGS="--timeout 120 --workers 3"
 
 CMD ["gunicorn", "wsgi:app", "-c", "run/gunicorn/run.py"]


### PR DESCRIPTION
### Change description
Increasing gunicorn worker timeout from 60 to 120 seconds in an attempt to prevent prod from crashing on download.

- [X] Unit tests and other appropriate tests added or updated
- [X] README and other documentation has been updated / added (if needed)
- [X] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
_If manual testing is needed, give suggested testing steps_


### Screenshots of UI changes (if applicable)
