### PR TITLE
FMD-46: Increase timeout to 180 seconds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ COPY . .
 EXPOSE 8080
 
 ENV FLASK_ENV=dev
-ENV GUNICORN_CMD_ARGS="--timeout 120 --workers 3"
+ENV GUNICORN_CMD_ARGS="--timeout 180 --workers 3"
 
 CMD ["gunicorn", "wsgi:app", "-c", "run/gunicorn/run.py"]


### PR DESCRIPTION
## Change description
Increasing timeout further to maximum of 180 seconds.


### How to test
Will re-test download after deployment. Increased to match increase in cloudfront timeout.


### Screenshots of UI changes (if applicable)
