### PR TITLE
FMD-105: Increase NGINX proxy read timeout

### DIFF
--- a/copilot/data-frontend/manifest.yml
+++ b/copilot/data-frontend/manifest.yml
@@ -63,6 +63,7 @@ environments:
         location: xscys/nginx-sidecar-basic-auth
       variables:
         FORWARD_PORT: 8080
+        PROXY_READ_TIMEOUT: 180s
       secrets:
         BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
         BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD


### PR DESCRIPTION
### Change description
In pre-prod environments requests were also being timed out by the default 60s timeout on NGINX. This increases it to match the Load Balancer and CDN timeouts.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Have deployed and tested on dev environment


### Screenshots of UI changes (if applicable)
