### PR TITLE
Feature/fmd 107 landing page dynamic filters

### DIFF
--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -1,7 +1,7 @@
 from flask_wtf import FlaskForm
 from govuk_frontend_wtf.wtforms_widgets import GovRadioInput, GovSelect, GovSubmitInput
 from wtforms.fields import RadioField, SelectField, SubmitField
-from wtforms.validators import InputRequired
+from wtforms.validators import AnyOf, InputRequired
 
 
 class CookiesForm(FlaskForm):
@@ -30,7 +30,7 @@ class DownloadForm(FlaskForm):
     file_format = SelectField(
         "File type",
         widget=GovSelect(),
-        validators=[InputRequired(message="Select the data format")],
+        validators=[AnyOf(["json", "xlsx"])],
         choices=[
             ("xlsx", "XSLX (Excel)"),
             ("json", "JSON"),

--- a/app/main/forms.py
+++ b/app/main/forms.py
@@ -28,7 +28,7 @@ class CookiesForm(FlaskForm):
 
 class DownloadForm(FlaskForm):
     file_format = SelectField(
-        "File Format",
+        "File type",
         widget=GovSelect(),
         validators=[InputRequired(message="Select the data format")],
         choices=[

--- a/app/static/src/css/custom.css
+++ b/app/static/src/css/custom.css
@@ -2,12 +2,17 @@
     background-image: url("/static/images/govuk-crest.png")
 }
 
+
 .govuk-button {
     background-color: #1d70b8;
 }
+
+
 .govuk-button:hover {
     background-color: #12066d;
 }
+
+
 .govuk-footer__meta {
     display: flex;
     margin-right: -15px;
@@ -19,6 +24,7 @@
     -ms-flex-pack: center;
     justify-content: center;
 }
+
 
 .global-actions {
     display: flex;
@@ -32,7 +38,25 @@
       }
 }
 
+
 .scrollable-checkboxes {
     max-height: 250px;
     overflow-y: auto;
   }
+
+
+.card {
+  background-color: #f3f2f1;
+  padding: 16px;
+  margin: 16px 0;
+}
+
+
+.green-button {
+    background-color: #00703c;
+    width: 100%;
+}
+
+.green-button:hover {
+    background-color: #005a30;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -22,6 +22,7 @@
   {{ govukHeader({
     'homepageUrl': url_for('main.download'),
     'serviceUrl': url_for('main.download'),
+    'serviceName':  config['SERVICE_NAME'],
   }) }}
 {% endblock %}
 

--- a/app/templates/main/start_page.html
+++ b/app/templates/main/start_page.html
@@ -52,8 +52,7 @@
   <p class="govuk-caption-m">
     Check the meanings of terms and data in the
     <a href="https://find-monitoring-data.access-funding.levellingup.gov.uk/data-glossary">
-      data extract glossary
-    </a>.
+      data extract glossary</a>.
   </p>
 
 {% endblock %}

--- a/app/templates/main/start_page.html
+++ b/app/templates/main/start_page.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+
+{%- from 'govuk_frontend_jinja/components/button/macro.html' import govukButton -%}
+
+{% block beforeContent %}
+  {{ super() }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">Find monitoring data</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+      <div class="card">
+        <h2 class="govuk-heading-l">Filter then download</h2>
+        <p class="govuk-body">You can filter data by:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>fund</li>
+          <li>reporting period</li>
+          <li>region</li>
+          <li>funded organisation</li>
+          <li>outcome</li>
+          <li>dataset</li>
+        </ul>
+        {{ govukButton({
+          'text': "Start filtering",
+          'href': '/start',
+          'classes': 'green-button',
+        }) }}
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <div class="card">
+        <h2 class="govuk-heading-l">Download everything</h2>
+        <p class="govuk-body">Skip filtering and download all the data.</p>
+        <form method="post" action="{{ url_for('main.start_page') }}">
+          {{ form.csrf_token }}
+          {{ form.file_format }}
+          {{ govukButton({
+            'text': "Create file and download everything",
+            'classes': 'green-button',
+          }) }}
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <br>
+
+  <h2 class="govuk-heading-l">Understanding your data file</h2>
+  <p class="govuk-caption-m">
+    Check the meanings of terms and data in the
+    <a href="https://find-monitoring-data.access-funding.levellingup.gov.uk/data-glossary">
+      data extract glossary
+    </a>.
+  </p>
+
+{% endblock %}

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -18,9 +18,7 @@ class DefaultConfig(object):
         "DEPARTMENT_URL",
         "https://www.gov.uk/government/organisations/department-for-levelling-up-housing-and-communities",
     )
-    SERVICE_NAME = os.environ.get(
-        "SERVICE_NAME", "Download monitoring and evaluation data"
-    )
+    SERVICE_NAME = os.environ.get("SERVICE_NAME", "Find monitoring data")
     SERVICE_PHASE = os.environ.get("SERVICE_PHASE", "BETA")
     SERVICE_URL = os.environ.get("SERVICE_URL", "dev-service-url")
     SESSION_COOKIE_SECURE = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 from flask.testing import FlaskClient
 from fsd_utils.authentication.config import SupportedApp
@@ -49,3 +51,22 @@ def app_ctx(flask_test_client):
     """
     with flask_test_client.application.app_context():
         yield
+
+
+@pytest.fixture
+def mock_get_response_xlsx(flask_test_client, mocker):
+    mocker.patch(
+        "app.main.routes.process_api_response",
+        return_value=(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            io.BytesIO(b"xlsx data"),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_get_response_json(flask_test_client, mocker):
+    mocker.patch(
+        "app.main.routes.process_api_response",
+        return_value=("application/json", io.BytesIO(b'{"data": "test"}')),
+    )

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,4 +1,12 @@
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+from werkzeug.exceptions import InternalServerError
+
+from app.const import MIMETYPE
 from app.main.data import get_response
+from app.main.download_data import process_api_response
 
 
 def test_get_response_success(requests_mock, app_ctx):
@@ -8,3 +16,32 @@ def test_get_response_success(requests_mock, app_ctx):
 
     assert response.status_code == 200
     assert response.text == "Success"
+
+
+@patch("app.main.download_data.get_response")
+def test_process_api_response_success(mock_get_response):
+    real_response = MagicMock()
+    real_response.content = b"xlsx data"
+    real_response.headers = {"content-type": MIMETYPE.XLSX}
+
+    mock_get_response.return_value = real_response
+
+    query_params = {"file_format": "xlsx"}
+    content_type, file_content = process_api_response(query_params)
+
+    assert content_type == MIMETYPE.XLSX
+    assert isinstance(file_content, io.BytesIO)
+    assert file_content.getvalue() == b"xlsx data"
+
+
+@patch("app.main.download_data.get_response")
+def test_process_api_response_error_500(mock_get_response, app_ctx, caplog):
+    real_response = MagicMock()
+    real_response.status_code = 500
+    mock_get_response.return_value = real_response
+
+    query_params = {"file_format": "xlsx"}
+    with pytest.raises(InternalServerError) as err:
+        process_api_response(query_params)
+
+    assert err.value.code == 500


### PR DESCRIPTION
Landing page for dynamic filtering. 

figma: https://www.figma.com/proto/MCfX0eECedW7Gp2lAjqWlT/Find-Tool%3A-Filtering?node-id=774-394

Uses a different route to our current download; will be swapped out as the default route when work on dynamic filtering is complete.

Enables the user to download all of the data in the database with one button. Currently does not redirect to the first filter page as does not exist yet, and so redirects to itself. Relevant tests for /download were adapted to /start.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [ ] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")

Screenshot from changes in this PR:
<img width="383" alt="image" src="https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/35725316/fdb60db2-10b9-4e6b-8803-a4c05b93127b">

The design in figma:
<img width="359" alt="image" src="https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/35725316/31425b34-9396-456f-b201-17f898fb07a1">

