### PR TITLE
BAU: enable app level logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@ from flask_wtf.csrf import CSRFProtect
 from fsd_utils import init_sentry
 from fsd_utils.healthchecks.checkers import FlaskRunningChecker
 from fsd_utils.healthchecks.healthcheck import Healthcheck
+from fsd_utils.logging import logging
 from govuk_frontend_wtf.main import WTFormsHelpers
 from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
@@ -20,6 +21,7 @@ def create_app(config_class=Config):
     app = Flask(__name__, static_url_path="/static")
     csrf.init_app(app)
     app.config.from_object(config_class)
+    logging.init_app(app)
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.trim_blocks = True
     app.jinja_loader = ChoiceLoader(

--- a/config/envs/default.py
+++ b/config/envs/default.py
@@ -1,14 +1,16 @@
 import base64
+import logging
 import os
 from pathlib import Path
 
-from fsd_utils import configclass
+from fsd_utils import CommonConfig, configclass
 
 
 @configclass
 class DefaultConfig(object):
     FLASK_ROOT = str(Path(__file__).parent.parent.parent)
-
+    FLASK_ENV = CommonConfig.FLASK_ENV
+    FSD_LOG_LEVEL = logging.INFO
     CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "FSD.Support@levellingup.gov.uk")
     CONTACT_PHONE = os.environ.get("CONTACT_PHONE", "12345678910")
     DEPARTMENT_NAME = os.environ.get(

--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -1,3 +1,5 @@
+import logging
+
 from fsd_utils import configclass
 
 from config.envs.default import DefaultConfig
@@ -12,3 +14,4 @@ class DevelopmentConfig(DefaultConfig):
         )
         with open(_test_public_key_path, mode="rb") as public_key_file:
             RSA256_PUBLIC_KEY = public_key_file.read()
+    FSD_LOG_LEVEL = logging.DEBUG


### PR DESCRIPTION
### Change description

Previously app level logging was not enabled which meant that only server level gunicorn logs were outputted on the hosted environments.
This enables logging using the [existing logging functionality](https://github.com/communitiesuk/funding-service-design-utils?tab=readme-ov-file#logging) in utils

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
App should show app level logs when running locally


### Screenshots of UI changes (if applicable)
