### PR TITLE
SMD-615: Debug user for local development

### DIFF
--- a/config/envs/development.py
+++ b/config/envs/development.py
@@ -15,3 +15,11 @@ class DevelopmentConfig(DefaultConfig):
         with open(_test_public_key_path, mode="rb") as public_key_file:
             RSA256_PUBLIC_KEY = public_key_file.read()
     FSD_LOG_LEVEL = logging.DEBUG
+
+    DEBUG_USER_ON = True
+    DEBUG_USER = {
+        "full_name": "Development User",
+        "email": "dev@communities.gov.uk",
+        "roles": [],
+        "highest_role_map": {},
+    }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,6 +20,10 @@ babel==2.12.1
     #   flask-babel
 bandit==1.7.5
     # via -r requirements-dev.in
+beautifulsoup4==4.12.2
+    # via
+    #   -r requirements.txt
+    #   funding-service-design-utils
 black==22.12.0
     # via -r requirements-dev.in
 blinker==1.6.2
@@ -133,7 +137,7 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.2
+funding-service-design-utils==2.0.41
     # via -r requirements.txt
 gitdb==4.0.10
     # via gitpython
@@ -305,6 +309,10 @@ six==1.16.0
     #   thrift
 smmap==5.0.0
     # via gitdb
+soupsieve==2.5
+    # via
+    #   -r requirements.txt
+    #   beautifulsoup4
 sqlalchemy==2.0.13
     # via
     #   -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ async-timeout==4.0.2
     # via redis
 babel==2.12.1
     # via flask-babel
+beautifulsoup4==4.12.2
+    # via funding-service-design-utils
 blinker==1.6.2
     # via
     #   flask
@@ -76,7 +78,7 @@ flask-wtf==1.1.1
     #   govuk-frontend-wtf
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils==2.0.2
+funding-service-design-utils==2.0.41
     # via -r requirements.in
 govuk-frontend-jinja==2.6.0
     # via
@@ -157,6 +159,8 @@ six==1.16.0
     #   python-consul
     #   python-dateutil
     #   thrift
+soupsieve==2.5
+    # via beautifulsoup4
 sqlalchemy==2.0.13
     # via
     #   alembic

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from app import create_app
 @pytest.fixture()
 def mocked_auth(monkeypatch):
     def access_token(return_app=SupportedApp.POST_AWARD_FRONTEND, auto_redirect=True):
-        return {"accountId": "test-user"}
+        return {"accountId": "test-user", "roles": []}
 
     monkeypatch.setattr(
         "fsd_utils.authentication.decorators._check_access_token",


### PR DESCRIPTION
### Change description
Sister PR to: https://github.com/communitiesuk/funding-service-design-post-award-submit/pull/135

Overrides auth when running in development, using the existing override functionality in the `@login_required` decorator

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
When running locally, you should be able to access `/download` without going through Microsoft auth

### Screenshots of UI changes (if applicable)
