### PR TITLE
BAU: add basic auth on dev

### DIFF
--- a/copilot/data-frontend/manifest.yml
+++ b/copilot/data-frontend/manifest.yml
@@ -71,3 +71,20 @@ environments:
     healthcheck:
       path: /healthcheck
       port: 8080
+ dev:
+  sidecars:
+    nginx:
+      port: 8087
+      image:
+        location: xscys/nginx-sidecar-basic-auth
+      variables:
+        FORWARD_PORT: 8080
+        PROXY_READ_TIMEOUT: 180s
+      secrets:
+        BASIC_AUTH_USERNAME: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_USERNAME
+        BASIC_AUTH_PASSWORD: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/BASIC_AUTH_PASSWORD
+  http:
+    target_container: 'nginx'
+    healthcheck:
+      path: /healthcheck
+      port: 8080


### PR DESCRIPTION
### Change description
Sister PR to: https://github.com/communitiesuk/funding-service-design-post-award-submit/pull/144

Previously we had basic auth on test but not dev, this adds basic auth on dev.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Basic auth should be enabled on the dev environment


### Screenshots of UI changes (if applicable)
