### PR TITLE
Download/Email Confirmation Page

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -128,6 +128,15 @@ def download():
         )
 
 
+@bp.route("/request-received", methods=["GET", "POST"])
+@login_required(return_app=SupportedApp.POST_AWARD_FRONTEND)
+def request_received():
+    context = {
+        "user_email": g.user.email,
+    }
+    return render_template("request-received.html", context=context)
+
+
 @bp.route("/accessibility", methods=["GET"])
 @login_required(return_app=SupportedApp.POST_AWARD_FRONTEND)
 def accessibility():

--- a/app/templates/main/request-received.html
+++ b/app/templates/main/request-received.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <div class="govuk-panel govuk-panel--confirmation">
+            <h1 class="govuk-panel__title">
+                Request received
+            </h1>
+        </div>
+        <h2 class="govuk-heading-m govuk-!-margin-top-7">
+            What happens next
+        </h2>
+        <p class="govuk-body">
+            We will email a link to <span class="govuk-!-font-weight-bold">{{ context["user_email"] }}</span>.
+        </p>
+        <p class="govuk-body">
+            This may take anything up to 5 minutes to come through to your inbox.</p>
+        <h2 class="govuk-heading-m">
+            If you’ve not recieved the email</h2>
+        <p class="govuk-body">
+            If you cannot see the email in your inbox, check your junk or spam folder.
+            If you’re still having problems,
+            <a class="govuk-link govuk-link--no-visited-state" href="{{ url_for ('.download') }}">
+                request a new link to download your data</a> or email us at
+            <a class="govuk-link govuk-link--no-visited-state" href="mailto:{{ config.CONTACT_EMAIL }}">{{ config['CONTACT_EMAIL'] }}</a>.
+        </p>
+    </div>
+</div>
+
+{% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -141,3 +141,14 @@ def test_back_link(flask_test_client, url):
 def test_pages_we_need_to_make_work(flask_test_client, url):
     response = flask_test_client.get(url)
     assert response.status_code == 200
+
+
+def test_download_confirmation_page(flask_test_client):
+    response = flask_test_client.get("/request-received")
+    assert response.status_code == 200
+
+
+def test_user_not_signed(unauthenticated_flask_test_client):
+    response = unauthenticated_flask_test_client.get("/request-received")
+    assert response.status_code == 302
+    assert response.location == "authenticator/sessions/sign-out?return_app=post-award-frontend"


### PR DESCRIPTION
FPASF-100


Created the download/email confirmation page according to our designs.



The details

We are tweaking the ‘download report’ journey so that users aren’t left on a page with no indication that work is happening while the report is being generated.

<img width="1512" alt="Screenshot 2024-06-04 at 13 29 16" src="https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/assets/62668311/306d14d4-bcbb-4843-829f-f0ff023ef57b">



