### PR TITLE
FPASF-143: fix download report

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -113,7 +113,7 @@ def download():
         content_type, file_content = process_api_response(query_params)
 
         current_app.logger.info(
-            "Request for download by {user_id=} with {query_params=}",
+            "Request for download by {user_id} with {query_params}",
             extra={
                 "user_id": g.account_id,
                 "email": g.user.email,

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -118,6 +118,7 @@ def download():
                 "user_id": g.account_id,
                 "email": g.user.email,
                 "query_params": query_params,
+                "request_type": "download",
             },
         )
         return send_file(

--- a/scripts/extract_download_logs.py
+++ b/scripts/extract_download_logs.py
@@ -106,7 +106,7 @@ def main(args):
         logGroupName=f"/copilot/post-award-{ENVIRONMENT}-data-frontend",
         queryString="""fields @timestamp, @message
     | sort @timestamp asc
-    | limit 1000
+    | limit 10000
     | filter message LIKE /Request for download./ OR request_type = 'download'""",
         startTime=int(datetime.datetime.timestamp(start_time)),
         endTime=int(datetime.datetime.timestamp(end_time)),

--- a/scripts/extract_download_logs.py
+++ b/scripts/extract_download_logs.py
@@ -107,7 +107,7 @@ def main(args):
         queryString="""fields @timestamp, @message
     | sort @timestamp asc
     | limit 1000
-    | filter request_type = 'download'""",
+    | filter message LIKE /Request for download./ OR request_type = 'download'""",
         startTime=int(datetime.datetime.timestamp(start_time)),
         endTime=int(datetime.datetime.timestamp(end_time)),
     )["queryId"]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.mark.usefixtures("mock_get_response_xlsx")
+def test_download_logging(flask_test_client, caplog):
+    flask_test_client.post("/download", data={"file_format": "xlsx"})
+    log_line = [record for record in caplog.records if hasattr(record, "request_type")]
+    assert len(log_line) == 1
+    assert log_line[0].request_type == "download"
+    assert log_line[0].user_id == "test-user"
+    assert log_line[0].query_params == {"file_format": "xlsx"}


### PR DESCRIPTION
### Change description
The download reporting mechanism was broken by the refactoring in: https://github.com/communitiesuk/funding-service-design-post-award-data-frontend/commit/025cf8f4844a72dba28c08fe3fe0a0888d642d18

This PR
* Restores the `request_type` key that was removed
* Makes the logs query backwards compatible so we can retrieve the logs using the refactored format
* Adds a unit test to make this interface harder to break in future

- [x] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Script should return results for recent period e.g. `python3 ./scripts/extract_download_logs.py -e dev -m 1` (with dev AWS credentials.)


### Screenshots of UI changes (if applicable)
