### PR TITLE
Pull in latest fsd_utils and upgrade sentry

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -132,7 +132,7 @@ flipper-client==1.3.2
     # via
     #   -r requirements.txt
     #   funding-service-design-utils
-funding-service-design-utils==2.0.41
+funding-service-design-utils==2.0.52
     # via -r requirements.txt
 gitdb==4.0.10
     # via gitpython
@@ -144,10 +144,6 @@ govuk-frontend-jinja==2.6.0
     #   govuk-frontend-wtf
 govuk-frontend-wtf==2.4.0
     # via -r requirements.txt
-greenlet==3.0.3
-    # via
-    #   -r requirements.txt
-    #   sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements.txt
@@ -187,6 +183,7 @@ markupsafe==2.1.2
     #   -r requirements.txt
     #   jinja2
     #   mako
+    #   sentry-sdk
     #   werkzeug
     #   wtforms
 mccabe==0.7.0
@@ -297,7 +294,7 @@ s3transfer==0.6.1
     # via
     #   -r requirements.txt
     #   boto3
-sentry-sdk[flask]==1.22.2
+sentry-sdk[flask]==1.45.0
     # via
     #   -r requirements.txt
     #   funding-service-design-utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ flask-wtf==1.1.1
     #   govuk-frontend-wtf
 flipper-client==1.3.2
     # via funding-service-design-utils
-funding-service-design-utils==2.0.41
+funding-service-design-utils==2.0.52
     # via -r requirements.in
 govuk-frontend-jinja==2.6.0
     # via
@@ -88,8 +88,6 @@ govuk-frontend-jinja==2.6.0
     #   govuk-frontend-wtf
 govuk-frontend-wtf==2.4.0
     # via -r requirements.in
-greenlet==3.0.3
-    # via sqlalchemy
 gunicorn==20.1.0
     # via
     #   -r requirements.in
@@ -120,6 +118,7 @@ markupsafe==2.1.2
     # via
     #   jinja2
     #   mako
+    #   sentry-sdk
     #   werkzeug
     #   wtforms
 notifications-python-client==9.0.0
@@ -161,7 +160,7 @@ rich==12.6.0
     # via funding-service-design-utils
 s3transfer==0.6.1
     # via boto3
-sentry-sdk[flask]==1.22.2
+sentry-sdk[flask]==1.45.0
     # via funding-service-design-utils
 six==1.16.0
     # via


### PR DESCRIPTION
### Change description
Pull in latest fsd_utils, so that we can use the latest version of sentry.