### PR TITLE
BAU: Filter out email_address key as that was breaking reporting

### DIFF
--- a/scripts/extract_download_logs.py
+++ b/scripts/extract_download_logs.py
@@ -57,12 +57,13 @@ def cloudwatch_logs_to_rows(data: List[List[dict]]) -> List[dict]:
         user_id = message["user_id"]
         email = message.get("email")
         query_params = message.get("query_params", {})
+        query_params_without_email_address = {k: v for k, v in query_params.items() if k != "email_address"}
         timestamp = [i for i in item if i["field"] == "@timestamp"][0]["value"]
         return {
             "timestamp": timestamp,
             "user_id": user_id,
             "email": email,
-            **query_params,
+            **query_params_without_email_address,
         }
 
     return [parse_item(item) for item in data]


### PR DESCRIPTION
### Change description
Since the `email_address` key was added as part of the async work this broke the `extract_download_logs` report as it expects all `fieldnames` to be explicitly defined.

This fixes it by removing `email_address` from the serialised fields if present.

- [ ] Unit tests and other appropriate tests added or updated
- [ ] README and other documentation has been updated / added (if needed)
- [x] Commit messages are meaningful and follow good commit message guidelines (e.g. "FS-XXXX: Add margin to nav items preventing overlapping of logo")


### How to test
Script should succeed e.g. ` python3 ./scripts/extract_download_logs.py -e dev -d 14 -f output.csv`

### Screenshots of UI changes (if applicable)
